### PR TITLE
feat: change inputPin (RB0 to RA0)

### DIFF
--- a/SM_Control.cpp
+++ b/SM_Control.cpp
@@ -39,7 +39,7 @@ void main(void) {
     OSCCONbits.IRCF = 0b1011;   // 1MHz
 
     while(1){
-        if(RB0 == 1){ // 90°      
+        if(RA0 == 1){ // 90°      
             RB3 = 1;
             __delay_us(1450);
             RB3 = 0;


### PR DESCRIPTION
related https://github.com/RC-FlyingRobot/programs-2025/issues/1#issue-3132834197

### 背景
去年からのレギュレーション変更により, 自動でサーボを投下できるようにしないといけないらしい

## 変更点
変更前:：フライトコントローラからRB0をLOW -> それを読み取っていた
変更後：入力ピンんをRB0からRA0(赤外線の出力ピン）に変更した

discord 引用
<img width="546" alt="Image" src="https://github.com/user-attachments/assets/f6c48c57-1462-47d1-a7ae-f6dc67c386ff" />